### PR TITLE
Add release-a-library Dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,32 @@
+version: 2.1
+
+orbs:
+  zulip: ponylang/zulip@1
+
+jobs:
+  release-a-library:
+    docker:
+      - image: ponylang/shared-docker-ci-docker-builder:20190808
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build and push the `release-a-library` Docker image
+          command: |
+            docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
+            bash release-a-library/build-and-push.bash
+      - zulip/status
+
+workflows:
+  version: 2.1
+
+  daily-image-updates:
+    triggers:
+      - schedule:
+          cron: "0 5 * * *"
+          filters:
+            branches:
+              only: master
+    jobs:
+      - release-a-library:
+          context: org-global

--- a/docker-builder/Dockerfile
+++ b/docker-builder/Dockerfile
@@ -1,0 +1,7 @@
+FROM docker:17.05.0-ce-git
+
+RUN apk update \
+  && apk upgrade \
+  && apk add --update \
+    bash \
+    curl

--- a/docker-builder/build-and-push.bash
+++ b/docker-builder/build-and-push.bash
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+#
+# *** You should already be logged in to DockerHub when you run this ***
+#
+
+TODAY=$(date +%Y%m%d)
+DOCKERFILE_DIR="$(dirname "$0")"
+
+docker build -t "ponylang/shared-docker-ci-docker-builder:${TODAY}" \
+  "${DOCKERFILE_DIR}"
+docker push "ponylang/shared-docker-ci-docker-builder:${TODAY}"

--- a/release-a-library/Dockerfile
+++ b/release-a-library/Dockerfile
@@ -1,0 +1,22 @@
+ARG FROM_TAG=release
+FROM ponylang/changelog-tool:release AS changelog-tool
+
+FROM ponylang/ponyc:${FROM_TAG}
+
+COPY --from=changelog-tool /usr/local/bin/changelog-tool /usr/local/bin/changelog-tool
+
+RUN  apt-get update && \
+  apt-get -y install \
+  curl \
+  git \
+  jq
+
+RUN curl -O 'https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/stable-x86-64-unknown-linux.tar.gz' \
+&& tar xvf stable* \
+&& cp nightly-*/bin/stable /usr/local/bin/ \
+&& rm -rf nightly-* *.tar.gz
+
+RUN curl -O 'https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/corral-x86-64-unknown-linux.tar.gz' \
+&& tar xvf corral* \
+&& cp nightly-*/bin/corral /usr/local/bin \
+&& rm -rf nightly-* *.tar.gz

--- a/release-a-library/README.md
+++ b/release-a-library/README.md
@@ -1,0 +1,13 @@
+# Release a library
+
+Base image for releasing Pony libraries.
+
+Comes with two tags:
+
+- release
+
+  Is built from the `ponyc:release` tag.
+
+- latest
+
+  Is built from the `ponyc:latest` tag

--- a/release-a-library/build-and-push.bash
+++ b/release-a-library/build-and-push.bash
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+#
+# *** You should already be logged in to DockerHub when you run this ***
+#
+
+DOCKERFILE_DIR="$(dirname "$0")"
+
+# built from ponyc release tag
+FROM_TAG=release
+docker build --build-arg FROM_TAG="${FROM_TAG}" \
+  -t ponylang/shared-docker-ci-release-a-library:"${FROM_TAG}" \
+  "${DOCKERFILE_DIR}"
+docker push ponylang/shared-docker-ci-release-a-library:"${FROM_TAG}"
+
+# built from ponyc latest tag
+FROM_TAG=latest
+docker build --build-arg FROM_TAG="${FROM_TAG}" \
+  -t ponylang/shared-docker-ci-release-a-library:"${FROM_TAG}" \
+  "${DOCKERFILE_DIR}"
+docker push ponylang/shared-docker-ci-release-a-library:"${FROM_TAG}"


### PR DESCRIPTION
Also includes required files to add a daily rebuild of the release-a-library
Docker image as it is a rolling image based on the most recent ponyc release.