### PR TITLE
Make sure we are using the latest base images

### DIFF
--- a/docker-builder/build-and-push.bash
+++ b/docker-builder/build-and-push.bash
@@ -10,6 +10,6 @@ set -o nounset
 TODAY=$(date +%Y%m%d)
 DOCKERFILE_DIR="$(dirname "$0")"
 
-docker build -t "ponylang/shared-docker-ci-docker-builder:${TODAY}" \
+docker build --pull -t "ponylang/shared-docker-ci-docker-builder:${TODAY}" \
   "${DOCKERFILE_DIR}"
 docker push "ponylang/shared-docker-ci-docker-builder:${TODAY}"

--- a/release-a-library/build-and-push.bash
+++ b/release-a-library/build-and-push.bash
@@ -11,14 +11,14 @@ DOCKERFILE_DIR="$(dirname "$0")"
 
 # built from ponyc release tag
 FROM_TAG=release
-docker build --build-arg FROM_TAG="${FROM_TAG}" \
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
   -t ponylang/shared-docker-ci-release-a-library:"${FROM_TAG}" \
   "${DOCKERFILE_DIR}"
 docker push ponylang/shared-docker-ci-release-a-library:"${FROM_TAG}"
 
 # built from ponyc latest tag
 FROM_TAG=latest
-docker build --build-arg FROM_TAG="${FROM_TAG}" \
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
   -t ponylang/shared-docker-ci-release-a-library:"${FROM_TAG}" \
   "${DOCKERFILE_DIR}"
 docker push ponylang/shared-docker-ci-release-a-library:"${FROM_TAG}"

--- a/release/build-and-push.bash
+++ b/release/build-and-push.bash
@@ -10,6 +10,6 @@ set -o nounset
 TODAY=$(date +%Y%m%d)
 DOCKERFILE_DIR="$(dirname "$0")"
 
-docker build -t "ponylang/shared-docker-ci-release:${TODAY}" \
+docker build --pull -t "ponylang/shared-docker-ci-release:${TODAY}" \
   "${DOCKERFILE_DIR}"
 docker push "ponylang/shared-docker-ci-release:${TODAY}"

--- a/shellcheck/build-and-push.bash
+++ b/shellcheck/build-and-push.bash
@@ -10,6 +10,6 @@ set -o nounset
 TODAY=$(date +%Y%m%d)
 DOCKERFILE_DIR="$(dirname "$0")"
 
-docker build -t "ponylang/shared-docker-ci-shellcheck:${TODAY}" \
+docker build --pull -t "ponylang/shared-docker-ci-shellcheck:${TODAY}" \
   "${DOCKERFILE_DIR}"
 docker push "ponylang/shared-docker-ci-shellcheck:${TODAY}"

--- a/x86-64-unknown-linux-builder-with-pcre/build-and-push.bash
+++ b/x86-64-unknown-linux-builder-with-pcre/build-and-push.bash
@@ -12,7 +12,7 @@ DOCKERFILE_DIR="$(dirname "$0")"
 # built from x86-64-unknown-linux-builder release tag
 FROM_TAG=release
 TAG_AS=release
-docker build --build-arg FROM_TAG="${FROM_TAG}" \
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
   -t ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-pcre:"${TAG_AS}" \
   "${DOCKERFILE_DIR}"
 docker push ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-pcre:"${TAG_AS}"
@@ -20,7 +20,7 @@ docker push ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-pcre:"${
 # built from x86-64-unknown-linux-builder latest tag
 FROM_TAG=latest
 TAG_AS=latest
-docker build --build-arg FROM_TAG="${FROM_TAG}" \
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
   -t ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-pcre:"${TAG_AS}" \
   "${DOCKERFILE_DIR}"
 docker push ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-pcre:"${TAG_AS}"

--- a/x86-64-unknown-linux-builder-with-ssl/build-and-push.bash
+++ b/x86-64-unknown-linux-builder-with-ssl/build-and-push.bash
@@ -12,7 +12,7 @@ DOCKERFILE_DIR="$(dirname "$0")"
 # built from x86-64-unknown-linux-builder release tag
 FROM_TAG=release
 TAG_AS=release
-docker build --build-arg FROM_TAG="${FROM_TAG}" \
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
   -t ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-ssl:"${TAG_AS}" \
   "${DOCKERFILE_DIR}"
 docker push ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-ssl:"${TAG_AS}"
@@ -20,7 +20,7 @@ docker push ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-ssl:"${T
 # built from x86-64-unknown-linux-builder latest tag
 FROM_TAG=latest
 TAG_AS=latest
-docker build --build-arg FROM_TAG="${FROM_TAG}" \
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
   -t ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-ssl:"${TAG_AS}" \
   "${DOCKERFILE_DIR}"
 docker push ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-ssl:"${TAG_AS}"

--- a/x86-64-unknown-linux-builder/build-and-push.bash
+++ b/x86-64-unknown-linux-builder/build-and-push.bash
@@ -12,7 +12,7 @@ DOCKERFILE_DIR="$(dirname "$0")"
 # built from ponyc release tag
 FROM_TAG=release-alpine
 TAG_AS=release
-docker build --build-arg FROM_TAG="${FROM_TAG}" \
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
   -t ponylang/shared-docker-ci-x86-64-unknown-linux-builder:"${TAG_AS}" \
   "${DOCKERFILE_DIR}"
 docker push ponylang/shared-docker-ci-x86-64-unknown-linux-builder:"${TAG_AS}"
@@ -20,7 +20,7 @@ docker push ponylang/shared-docker-ci-x86-64-unknown-linux-builder:"${TAG_AS}"
 # built from ponyc latest tag
 FROM_TAG=alpine
 TAG_AS=latest
-docker build --build-arg FROM_TAG="${FROM_TAG}" \
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
   -t ponylang/shared-docker-ci-x86-64-unknown-linux-builder:"${TAG_AS}" \
   "${DOCKERFILE_DIR}"
 docker push ponylang/shared-docker-ci-x86-64-unknown-linux-builder:"${TAG_AS}"


### PR DESCRIPTION
In a CI environment, it is unlikely that we need `docker --pull`.
We probably don't have the base images cached. However, if someone
is using locally then we have a much higher chance.

This commit adds a `docker --pull` for all build command to make
sure we are using the latest base images when we build.