### PR TITLE
Create new OpenSSL testing image where we build 1.1.1 from source

### DIFF
--- a/.github/workflows/image-rebuilding-second-level.yml
+++ b/.github/workflows/image-rebuilding-second-level.yml
@@ -31,6 +31,19 @@ jobs:
       - name: Build and push
         run: bash x86-64-unknown-linux-builder-with-openssl_1.1.x/build-and-push.bash
 
+  x86-64-unknown-linux-builder-with-openssl_1_1_1g:
+    name: Update x86-64-unknown-linux-builder-with-openssl_1.1.1g
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Docker login
+        run: "docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD"
+        env:
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: Build and push
+        run: bash x86-64-unknown-linux-builder-with-openssl_1.1.1g/build-and-push.bash
+
   x86-64-unknown-linux-builder-with-pcre:
     name: Update x86-64-unknown-linux-builder-with-pcre
     runs-on: ubuntu-latest

--- a/x86-64-unknown-linux-builder-with-openssl_1.1.1g/Dockerfile
+++ b/x86-64-unknown-linux-builder-with-openssl_1.1.1g/Dockerfile
@@ -1,0 +1,18 @@
+ARG FROM_TAG=release
+FROM ponylang/shared-docker-ci-x86-64-unknown-linux-builder:${FROM_TAG}
+
+RUN apk update \
+  && apk upgrade \
+  && apk add --update \
+  clang-dev \
+  linux-headers \
+  perl
+
+RUN cd /tmp && \
+  wget https://github.com/openssl/openssl/archive/OpenSSL_1_1_1g.tar.gz && \
+  tar xf OpenSSL_1_1_1g.tar.gz && \
+  cd openssl-OpenSSL_1_1_1g && \
+  ./Configure --api=1.1.0 no-shared linux-x86_64 enable-rc5 enable-md2 && \
+  make install_sw && \
+  cd /tmp && \
+  rm -rf openssl-OpenSSL_1_1_1g

--- a/x86-64-unknown-linux-builder-with-openssl_1.1.1g/README.md
+++ b/x86-64-unknown-linux-builder-with-openssl_1.1.1g/README.md
@@ -1,0 +1,3 @@
+# x86-64-unknown-linux-builder-with-openssl_1.1.1g
+
+The x86-64-unknown-linux-builder with OpenSSL 1.1.1g implementation installed as well. Rebuilt daily.

--- a/x86-64-unknown-linux-builder-with-openssl_1.1.1g/build-and-push.bash
+++ b/x86-64-unknown-linux-builder-with-openssl_1.1.1g/build-and-push.bash
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+#
+# *** You should already be logged in to DockerHub when you run this ***
+#
+
+DOCKERFILE_DIR="$(dirname "$0")"
+IMAGE="ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_1.1.1g"
+
+# built from x86-64-unknown-linux-builder release tag
+FROM_TAG=release
+TAG_AS=release
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
+  -t "${IMAGE}:${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push "${IMAGE}:${TAG_AS}"
+
+# built from x86-64-unknown-linux-builder latest tag
+FROM_TAG=latest
+TAG_AS=latest
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
+  -t "${IMAGE}:${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push "${IMAGE}:${TAG_AS}"


### PR DESCRIPTION
This allows us to not have the version change out from underneath
us as well as turn on algos that aren't often on in a particular
distros version.

Note, until such time as it is deprecated, the old "with-openssl-*"
environment will continue to be maintained. Probably for a couple of
weeks as we transition off and let folks who might be using it know.

Closes #9