### PR TITLE
Add new libressl testing environment

### DIFF
--- a/.github/workflows/image-rebuilding-second-level.yml
+++ b/.github/workflows/image-rebuilding-second-level.yml
@@ -18,6 +18,19 @@ jobs:
       - name: Build and push
         run: bash x86-64-unknown-linux-builder-with-libressl/build-and-push.bash
 
+  x86-64-unknown-linux-builder-with-libressl_3_1_2:
+    name: Update x86-64-unknown-linux-builder-with-libressl-3.1.2
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Docker login
+        run: "docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD"
+        env:
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: Build and push
+        run: bash x86-64-unknown-linux-builder-with-libressl-3.1.2/build-and-push.bash
+
   x86-64-unknown-linux-builder-with-openssl_1_1_x:
     name: Update x86-64-unknown-linux-builder-with-openssl_1.1.x
     runs-on: ubuntu-latest

--- a/x86-64-unknown-linux-builder-with-libressl-3.1.2/Dockerfile
+++ b/x86-64-unknown-linux-builder-with-libressl-3.1.2/Dockerfile
@@ -1,0 +1,11 @@
+ARG FROM_TAG=release
+FROM ponylang/shared-docker-ci-x86-64-unknown-linux-builder:${FROM_TAG}
+
+RUN cd /tmp && \
+  wget https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.1.2.tar.gz && \
+  tar xf libressl-3.1.2.tar.gz && \
+  cd libressl-3.1.2/ && \
+  ./configure && \
+  make install && \
+  cd /tmp && \
+  rm -rf libressl*

--- a/x86-64-unknown-linux-builder-with-libressl-3.1.2/README.md
+++ b/x86-64-unknown-linux-builder-with-libressl-3.1.2/README.md
@@ -1,0 +1,3 @@
+# x86-64-unknown-linux-builder-with-libressl-3.1.2
+
+The x86-64-unknown-linux-builder with libressl 3.1.2 SSL implementation installed as well. Rebuilt daily.

--- a/x86-64-unknown-linux-builder-with-libressl-3.1.2/build-and-push.bash
+++ b/x86-64-unknown-linux-builder-with-libressl-3.1.2/build-and-push.bash
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+#
+# *** You should already be logged in to DockerHub when you run this ***
+#
+
+DOCKERFILE_DIR="$(dirname "$0")"
+IMAGE="ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-libressl-3.1.2"
+
+# built from x86-64-unknown-linux-builder release tag
+FROM_TAG=release
+TAG_AS=release
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
+  -t "${IMAGE}:${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push "${IMAGE}:${TAG_AS}"
+
+# built from x86-64-unknown-linux-builder latest tag
+FROM_TAG=latest
+TAG_AS=latest
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
+  -t "${IMAGE}:${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push "${IMAGE}:${TAG_AS}"


### PR DESCRIPTION
Our other libressl environment uses whatever version of libressl that
alpine's package manager installs. This new environment is tied to a
specific version of libressl that we build from source.

This gives us more control over what is tested and when we change
what is tested.

Closes #10