### PR TITLE
Rebuild linux builder images after new nightly docker image is created

### DIFF
--- a/.github/workflows/image-rebuilding.yml
+++ b/.github/workflows/image-rebuilding.yml
@@ -1,4 +1,4 @@
-name: Rebuild auto updating images
+name: Rebuild auto updating release-a-library
 
 on:
   schedule:
@@ -17,58 +17,3 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       - name: Build and push
         run: bash release-a-library/build-and-push.bash
-
-  x86-64-unknown-linux-builder:
-    name: Update x86-64-unknown-linux-builder
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Docker login
-        run: "docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD"
-        env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      - name: Build and push
-        run: bash x86-64-unknown-linux-builder/build-and-push.bash
-
-  x86-64-unknown-linux-builder-with-libressl_3_1_2:
-    name: Update x86-64-unknown-linux-builder-with-libressl-3.1.2
-    runs-on: ubuntu-latest
-    needs: [x86-64-unknown-linux-builder]
-    steps:
-      - uses: actions/checkout@v1
-      - name: Docker login
-        run: "docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD"
-        env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      - name: Build and push
-        run: bash x86-64-unknown-linux-builder-with-libressl-3.1.2/build-and-push.bash
-
-  x86-64-unknown-linux-builder-with-openssl_1_1_1g:
-    name: Update x86-64-unknown-linux-builder-with-openssl_1.1.1g
-    runs-on: ubuntu-latest
-    needs: [x86-64-unknown-linux-builder]
-    steps:
-      - uses: actions/checkout@v1
-      - name: Docker login
-        run: "docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD"
-        env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      - name: Build and push
-        run: bash x86-64-unknown-linux-builder-with-openssl_1.1.1g/build-and-push.bash
-
-  x86-64-unknown-linux-builder-with-pcre:
-    name: Update x86-64-unknown-linux-builder-with-pcre
-    runs-on: ubuntu-latest
-    needs: [x86-64-unknown-linux-builder]
-    steps:
-      - uses: actions/checkout@v1
-      - name: Docker login
-        run: "docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD"
-        env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      - name: Build and push
-        run: bash x86-64-unknown-linux-builder-with-pcre/build-and-push.bash

--- a/.github/workflows/linux-builder-update.yml
+++ b/.github/workflows/linux-builder-update.yml
@@ -1,0 +1,61 @@
+name: Rebuild linux builder images
+
+on:
+  repository_dispatch:
+    types: [ponyc-nightly-released]
+
+jobs:
+  x86-64-unknown-linux-builder:
+    name: Update x86-64-unknown-linux-builder
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Docker login
+        run: "docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD"
+        env:
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: Build and push
+        run: bash x86-64-unknown-linux-builder/build-and-push.bash
+
+  x86-64-unknown-linux-builder-with-libressl_3_1_2:
+    name: Update x86-64-unknown-linux-builder-with-libressl-3.1.2
+    runs-on: ubuntu-latest
+    needs: [x86-64-unknown-linux-builder]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Docker login
+        run: "docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD"
+        env:
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: Build and push
+        run: bash x86-64-unknown-linux-builder-with-libressl-3.1.2/build-and-push.bash
+
+  x86-64-unknown-linux-builder-with-openssl_1_1_1g:
+    name: Update x86-64-unknown-linux-builder-with-openssl_1.1.1g
+    runs-on: ubuntu-latest
+    needs: [x86-64-unknown-linux-builder]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Docker login
+        run: "docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD"
+        env:
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: Build and push
+        run: bash x86-64-unknown-linux-builder-with-openssl_1.1.1g/build-and-push.bash
+
+  x86-64-unknown-linux-builder-with-pcre:
+    name: Update x86-64-unknown-linux-builder-with-pcre
+    runs-on: ubuntu-latest
+    needs: [x86-64-unknown-linux-builder]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Docker login
+        run: "docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD"
+        env:
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: Build and push
+        run: bash x86-64-unknown-linux-builder-with-pcre/build-and-push.bash


### PR DESCRIPTION
With this change, we move from rebuilding linux builder images on a set
daily schedule to doing when we get a respository dispatch event from the
ponyc repo that a release has been done.

Currently ponyc will only send an event for a nightly release as such,
this commit breaks updating when there is a new release. Once this runs
for a day and I know it works, I'll be adding in support for also doing
on a regular release, not just a nightly.

This is an intermediate step in getting all this to work as it is the first
time that we are using repository dispatch sending within our own repos.