### PR TITLE
Rebuild release-a-library image based on repository_dispatch events

### DIFF
--- a/.github/workflows/release-a-library-update.yml
+++ b/.github/workflows/release-a-library-update.yml
@@ -1,8 +1,8 @@
-name: Rebuild auto updating release-a-library
+name: Rebuild release-a-library image
 
 on:
-  schedule:
-    - cron: "0 1 * * *"
+  repository_dispatch:
+    types: [ponyc-musl-nightly-released, ponyc-musl-released, changelog-tool-released]
 
 jobs:
   release-a-library:


### PR DESCRIPTION
Switched from rebuilding daily based on a schedule to on demand as needed.
We depend on 3 things:

- ponyc musl release image
- ponyc musl latest image
- changelog-tool release image

With this change, the release-a-library image will be rebuilt any time
we are notified of an event for any of our three dependencies.