### PR TITLE
Set up git to turn off "safe directory" warnings

### DIFF
--- a/release-a-library/Dockerfile
+++ b/release-a-library/Dockerfile
@@ -11,3 +11,5 @@ RUN apk add --update --no-cache \
   git \
   jq \
   make
+
+RUN git config --global --add safe.directory '*'

--- a/x86-64-unknown-linux-builder/Dockerfile
+++ b/x86-64-unknown-linux-builder/Dockerfile
@@ -12,3 +12,5 @@ RUN apk add --update --no-cache \
   libexecinfo-dev \
   libexecinfo-static \
   && pip install cloudsmith-cli
+
+RUN git config --global --add safe.directory '*'


### PR DESCRIPTION
Address them in one place rather than many. With containers and uid mapping issues, this is pretty much a nightmare feature with mounted volumes.