### PR TITLE
Put shared images in both GitHub Container Registry and DockerHub

### DIFF
--- a/.github/workflows/linux-builder-update.yml
+++ b/.github/workflows/linux-builder-update.yml
@@ -12,11 +12,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Docker login
+      - name: Login to DockerHub
         run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         run: bash x86-64-unknown-linux-builder/build-and-push.bash
       - name: Send alert on failure
@@ -39,11 +46,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Docker login
+      - name: Login to DockerHub
         run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         run: bash x86-64-unknown-linux-builder-with-libressl-3.5.3/build-and-push.bash
       - name: Send alert on failure
@@ -66,11 +80,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Docker login
+      - name: Login to DockerHub
         run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         run: bash x86-64-unknown-linux-builder-with-libressl-3.7.2/build-and-push.bash
       - name: Send alert on failure
@@ -93,11 +114,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Docker login
+      - name: Login to DockerHub
         run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         run: bash x86-64-unknown-linux-builder-with-openssl_1.1.1q/build-and-push.bash
       - name: Send alert on failure
@@ -120,11 +148,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Docker login
+      - name: Login to DockerHub
         run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         run: bash x86-64-unknown-linux-builder-with-openssl_1.1.1t/build-and-push.bash
       - name: Send alert on failure
@@ -147,11 +182,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Docker login
+      - name: Login to DockerHub
         run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         run: bash x86-64-unknown-linux-builder-with-openssl_3.0.7/build-and-push.bash
       - name: Send alert on failure
@@ -174,11 +216,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Docker login
+      - name: Login to DockerHub
         run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         run: bash x86-64-unknown-linux-builder-with-openssl_3.1.0/build-and-push.bash
       - name: Send alert on failure
@@ -201,11 +250,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Docker login
+      - name: Login to DockerHub
         run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         run: bash x86-64-unknown-linux-builder-with-pcre/build-and-push.bash
       - name: Send alert on failure
@@ -271,6 +327,47 @@ jobs:
           repository: ${{ matrix.repo }}
           event-type: shared-docker-linux-builders-updated
           client-payload: '{}'
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@b62d5a0e48a4d984ea4fce5dd65ba691963d4db4
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
+  prune-untagged-builder-images:
+    needs:
+      - send-linux-builders-updated-event
+
+    name: Prune untagged builder images
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - shared-docker-ci-x86-64-unknown-linux-builder
+          - shared-docker-ci-x86-64-unknown-linux-builder-with-libressl-3.5.3
+          - shared-docker-ci-x86-64-unknown-linux-builder-with-libressl-3.7.2
+          - shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_1.1.1q
+          - shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_1.1.1t
+          - shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_3.0.7
+          - shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_3.1.0
+          - shared-docker-ci-x86-64-unknown-linux-builder-with-pcre
+
+    steps:
+      - name: Prune
+        # v4.1.1
+        uses: actions/delete-package-versions@0d39a63126868f5eefaa47169615edd3c0f61e20
+        with:
+          package-name: ${{ matrix.image }}
+          package-type: 'container'
+          min-versions-to-keep: 1
+          delete-only-untagged-versions: 'true'
       - name: Send alert on failure
         if: ${{ failure() }}
         uses: zulip/github-actions-zulip/send-message@b62d5a0e48a4d984ea4fce5dd65ba691963d4db4

--- a/.github/workflows/release-a-library-update.yml
+++ b/.github/workflows/release-a-library-update.yml
@@ -13,13 +13,47 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Docker login
+      - name: Login to DockerHub
         run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         run: bash release-a-library/build-and-push.bash
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@b62d5a0e48a4d984ea4fce5dd65ba691963d4db4
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
+  prune-untagged-images:
+    needs:
+      - release-a-library
+
+    name: Prune untagged images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prune
+        # v4.1.1
+        uses: actions/delete-package-versions@0d39a63126868f5eefaa47169615edd3c0f61e20
+        with:
+          package-name: 'shared-docker-ci-release-a-library'
+          package-type: 'container'
+          min-versions-to-keep: 1
+          delete-only-untagged-versions: 'true'
       - name: Send alert on failure
         if: ${{ failure() }}
         uses: zulip/github-actions-zulip/send-message@b62d5a0e48a4d984ea4fce5dd65ba691963d4db4

--- a/actionlint/build-and-push.bash
+++ b/actionlint/build-and-push.bash
@@ -4,12 +4,19 @@ set -o errexit
 set -o nounset
 
 #
-# *** You should already be logged in to DockerHub when you run this ***
+# *** You should already be logged in to DockerHub
+#     and GitHub Container Registry when you run this ***
 #
 
 NAME="ponylang/shared-docker-ci-actionlint"
 TODAY=$(date +%Y%m%d)
 DOCKERFILE_DIR="$(dirname "$0")"
 
+# DockerHub
+docker build --pull -t "${NAME}:${TODAY}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TODAY}"
+
+# GitHub Container Registry
+NAME="ghcr.io/${NAME}"
 docker build --pull -t "${NAME}:${TODAY}" "${DOCKERFILE_DIR}"
 docker push "${NAME}:${TODAY}"

--- a/release-a-library/build-and-push.bash
+++ b/release-a-library/build-and-push.bash
@@ -4,23 +4,46 @@ set -o errexit
 set -o nounset
 
 #
-# *** You should already be logged in to DockerHub when you run this ***
+# *** You should already be logged in to DockerHub
+#     and GitHub Container Registry when you run this ***
 #
 
 DOCKERFILE_DIR="$(dirname "$0")"
 
+## DockerHub
+
 # built from ponyc release tag
+NAME="ponylang/shared-docker-ci-release-a-library"
 FROM_TAG=release-alpine
 TAG_AS=release
 docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t ponylang/shared-docker-ci-release-a-library:"${TAG_AS}" \
+  -t "${NAME}:${TAG_AS}" \
   "${DOCKERFILE_DIR}"
-docker push ponylang/shared-docker-ci-release-a-library:"${TAG_AS}"
+docker push "${NAME}:${TAG_AS}"
 
 # built from ponyc latest tag
 FROM_TAG=alpine
 TAG_AS=latest
 docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t ponylang/shared-docker-ci-release-a-library:"${TAG_AS}" \
+  -t "${NAME}:${TAG_AS}" \
   "${DOCKERFILE_DIR}"
-docker push ponylang/shared-docker-ci-release-a-library:"${TAG_AS}"
+docker push "${NAME}:${TAG_AS}"
+
+## GitHub Container Registry
+
+# built from ponyc release tag
+NAME="ghcr.io/ponylang/shared-docker-ci-release-a-library"
+FROM_TAG=release-alpine
+TAG_AS=release
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
+  -t "${NAME}:${TAG_AS}" \
+  "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"
+
+# built from ponyc latest tag
+FROM_TAG=alpine
+TAG_AS=latest
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
+  -t "${NAME}:${TAG_AS}" \
+  "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"

--- a/x86-64-unknown-linux-builder-with-libressl-3.5.3/build-and-push.bash
+++ b/x86-64-unknown-linux-builder-with-libressl-3.5.3/build-and-push.bash
@@ -4,22 +4,44 @@ set -o errexit
 set -o nounset
 
 #
-# *** You should already be logged in to DockerHub when you run this ***
+# *** You should already be logged in to DockerHub
+#     and GitHub Container Registry when you run this ***
 #
 
 DOCKERFILE_DIR="$(dirname "$0")"
-IMAGE="ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-libressl-3.5.3"
+
+## DockerHub
+
+NAME="ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-libressl-3.5.3"
 
 # built from x86-64-unknown-linux-builder release tag
 FROM_TAG=release
 TAG_AS=release
 docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t "${IMAGE}:${TAG_AS}" "${DOCKERFILE_DIR}"
-docker push "${IMAGE}:${TAG_AS}"
+  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"
 
 # built from x86-64-unknown-linux-builder latest tag
 FROM_TAG=latest
 TAG_AS=latest
 docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t "${IMAGE}:${TAG_AS}" "${DOCKERFILE_DIR}"
-docker push "${IMAGE}:${TAG_AS}"
+  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"
+
+## GitHub Container Registry
+
+NAME="ghcr.io/ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-libressl-3.5.3"
+
+# built from x86-64-unknown-linux-builder release tag
+FROM_TAG=release
+TAG_AS=release
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
+  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"
+
+# built from x86-64-unknown-linux-builder latest tag
+FROM_TAG=latest
+TAG_AS=latest
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
+  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"

--- a/x86-64-unknown-linux-builder-with-libressl-3.7.2/build-and-push.bash
+++ b/x86-64-unknown-linux-builder-with-libressl-3.7.2/build-and-push.bash
@@ -4,22 +4,44 @@ set -o errexit
 set -o nounset
 
 #
-# *** You should already be logged in to DockerHub when you run this ***
+# *** You should already be logged in to DockerHub
+#     and GitHub Container Registry when you run this ***
 #
 
 DOCKERFILE_DIR="$(dirname "$0")"
-IMAGE="ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-libressl-3.7.2"
+
+## DockerHub
+
+NAME="ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-libressl-3.7.2"
 
 # built from x86-64-unknown-linux-builder release tag
 FROM_TAG=release
 TAG_AS=release
 docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t "${IMAGE}:${TAG_AS}" "${DOCKERFILE_DIR}"
-docker push "${IMAGE}:${TAG_AS}"
+  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"
 
 # built from x86-64-unknown-linux-builder latest tag
 FROM_TAG=latest
 TAG_AS=latest
 docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t "${IMAGE}:${TAG_AS}" "${DOCKERFILE_DIR}"
-docker push "${IMAGE}:${TAG_AS}"
+  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"
+
+## GitHub Container Registry
+
+NAME="ghrc.io/ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-libressl-3.7.2"
+
+# built from x86-64-unknown-linux-builder release tag
+FROM_TAG=release
+TAG_AS=release
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
+  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"
+
+# built from x86-64-unknown-linux-builder latest tag
+FROM_TAG=latest
+TAG_AS=latest
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
+  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"

--- a/x86-64-unknown-linux-builder-with-openssl_1.1.1q/build-and-push.bash
+++ b/x86-64-unknown-linux-builder-with-openssl_1.1.1q/build-and-push.bash
@@ -4,22 +4,44 @@ set -o errexit
 set -o nounset
 
 #
-# *** You should already be logged in to DockerHub when you run this ***
+# *** You should already be logged in to DockerHub
+#     and GitHub Container Registry when you run this ***
 #
 
 DOCKERFILE_DIR="$(dirname "$0")"
-IMAGE="ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_1.1.1q"
+
+## DockerHub
+
+NAME="ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_1.1.1q"
 
 # built from x86-64-unknown-linux-builder release tag
 FROM_TAG=release
 TAG_AS=release
 docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t "${IMAGE}:${TAG_AS}" "${DOCKERFILE_DIR}"
-docker push "${IMAGE}:${TAG_AS}"
+  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"
 
 # built from x86-64-unknown-linux-builder latest tag
 FROM_TAG=latest
 TAG_AS=latest
 docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t "${IMAGE}:${TAG_AS}" "${DOCKERFILE_DIR}"
-docker push "${IMAGE}:${TAG_AS}"
+  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"
+
+## GitHub Container Registry
+
+NAME="ghcr.io/ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_1.1.1q"
+
+# built from x86-64-unknown-linux-builder release tag
+FROM_TAG=release
+TAG_AS=release
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
+  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"
+
+# built from x86-64-unknown-linux-builder latest tag
+FROM_TAG=latest
+TAG_AS=latest
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
+  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"

--- a/x86-64-unknown-linux-builder-with-openssl_1.1.1t/build-and-push.bash
+++ b/x86-64-unknown-linux-builder-with-openssl_1.1.1t/build-and-push.bash
@@ -4,22 +4,44 @@ set -o errexit
 set -o nounset
 
 #
-# *** You should already be logged in to DockerHub when you run this ***
+# *** You should already be logged in to DockerHub
+#     and GitHub Container Registry when you run this ***
 #
 
 DOCKERFILE_DIR="$(dirname "$0")"
-IMAGE="ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_1.1.1t"
+
+## DockerHub
+
+NAME="ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_1.1.1t"
 
 # built from x86-64-unknown-linux-builder release tag
 FROM_TAG=release
 TAG_AS=release
 docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t "${IMAGE}:${TAG_AS}" "${DOCKERFILE_DIR}"
-docker push "${IMAGE}:${TAG_AS}"
+  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"
 
 # built from x86-64-unknown-linux-builder latest tag
 FROM_TAG=latest
 TAG_AS=latest
 docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t "${IMAGE}:${TAG_AS}" "${DOCKERFILE_DIR}"
-docker push "${IMAGE}:${TAG_AS}"
+  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"
+
+## GitHub Container Registry
+
+NAME="ghcr.io/ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_1.1.1t"
+
+# built from x86-64-unknown-linux-builder release tag
+FROM_TAG=release
+TAG_AS=release
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
+  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"
+
+# built from x86-64-unknown-linux-builder latest tag
+FROM_TAG=latest
+TAG_AS=latest
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
+  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"

--- a/x86-64-unknown-linux-builder-with-openssl_3.0.7/build-and-push.bash
+++ b/x86-64-unknown-linux-builder-with-openssl_3.0.7/build-and-push.bash
@@ -4,22 +4,44 @@ set -o errexit
 set -o nounset
 
 #
-# *** You should already be logged in to DockerHub when you run this ***
+# *** You should already be logged in to DockerHub
+#     and GitHub Container Registry when you run this ***
 #
 
 DOCKERFILE_DIR="$(dirname "$0")"
-IMAGE="ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_3.0.7"
+
+## DockerHub
+
+NAME="ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_3.0.7"
 
 # built from x86-64-unknown-linux-builder release tag
 FROM_TAG=release
 TAG_AS=release
 docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t "${IMAGE}:${TAG_AS}" "${DOCKERFILE_DIR}"
-docker push "${IMAGE}:${TAG_AS}"
+  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"
 
 # built from x86-64-unknown-linux-builder latest tag
 FROM_TAG=latest
 TAG_AS=latest
 docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t "${IMAGE}:${TAG_AS}" "${DOCKERFILE_DIR}"
-docker push "${IMAGE}:${TAG_AS}"
+  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"
+
+## GitHub Container Registry
+
+NAME="ghcr.io/ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_3.0.7"
+
+# built from x86-64-unknown-linux-builder release tag
+FROM_TAG=release
+TAG_AS=release
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
+  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"
+
+# built from x86-64-unknown-linux-builder latest tag
+FROM_TAG=latest
+TAG_AS=latest
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
+  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"

--- a/x86-64-unknown-linux-builder-with-openssl_3.1.0/build-and-push.bash
+++ b/x86-64-unknown-linux-builder-with-openssl_3.1.0/build-and-push.bash
@@ -4,22 +4,44 @@ set -o errexit
 set -o nounset
 
 #
-# *** You should already be logged in to DockerHub when you run this ***
+# *** You should already be logged in to DockerHub
+#     and GitHub Container Registry when you run this ***
 #
 
 DOCKERFILE_DIR="$(dirname "$0")"
-IMAGE="ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_3.1.0"
+
+## DockerHub
+
+NAME="ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_3.1.0"
 
 # built from x86-64-unknown-linux-builder release tag
 FROM_TAG=release
 TAG_AS=release
 docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t "${IMAGE}:${TAG_AS}" "${DOCKERFILE_DIR}"
-docker push "${IMAGE}:${TAG_AS}"
+  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"
 
 # built from x86-64-unknown-linux-builder latest tag
 FROM_TAG=latest
 TAG_AS=latest
 docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t "${IMAGE}:${TAG_AS}" "${DOCKERFILE_DIR}"
-docker push "${IMAGE}:${TAG_AS}"
+  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"
+
+## GitHub Container Registry
+
+NAME="ghcr.io/ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_3.1.0"
+
+# built from x86-64-unknown-linux-builder release tag
+FROM_TAG=release
+TAG_AS=release
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
+  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"
+
+# built from x86-64-unknown-linux-builder latest tag
+FROM_TAG=latest
+TAG_AS=latest
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
+  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"

--- a/x86-64-unknown-linux-builder-with-pcre/build-and-push.bash
+++ b/x86-64-unknown-linux-builder-with-pcre/build-and-push.bash
@@ -4,23 +4,48 @@ set -o errexit
 set -o nounset
 
 #
-# *** You should already be logged in to DockerHub when you run this ***
+# *** You should already be logged in to DockerHub
+#     and GitHub Container Registry when you run this ***
 #
 
 DOCKERFILE_DIR="$(dirname "$0")"
+
+## DockerHub
+
+NAME="ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-pcre"
 
 # built from x86-64-unknown-linux-builder release tag
 FROM_TAG=release
 TAG_AS=release
 docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-pcre:"${TAG_AS}" \
+  -t "${NAME}:${TAG_AS}" \
   "${DOCKERFILE_DIR}"
-docker push ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-pcre:"${TAG_AS}"
+docker push "${NAME}:${TAG_AS}"
 
 # built from x86-64-unknown-linux-builder latest tag
 FROM_TAG=latest
 TAG_AS=latest
 docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-pcre:"${TAG_AS}" \
+  -t "${NAME}:${TAG_AS}" \
   "${DOCKERFILE_DIR}"
-docker push ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-pcre:"${TAG_AS}"
+docker push "${NAME}:${TAG_AS}"
+
+## GitHub Container Registry
+
+NAME="ghcr.io/ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-pcre"
+
+# built from x86-64-unknown-linux-builder release tag
+FROM_TAG=release
+TAG_AS=release
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
+  -t "${NAME}:${TAG_AS}" \
+  "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"
+
+# built from x86-64-unknown-linux-builder latest tag
+FROM_TAG=latest
+TAG_AS=latest
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
+  -t "${NAME}:${TAG_AS}" \
+  "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"

--- a/x86-64-unknown-linux-builder/build-and-push.bash
+++ b/x86-64-unknown-linux-builder/build-and-push.bash
@@ -4,23 +4,46 @@ set -o errexit
 set -o nounset
 
 #
-# *** You should already be logged in to DockerHub when you run this ***
+# *** You should already be logged in to DockerHub
+#     and GitHub Container Registry when you run this ***
 #
 
 DOCKERFILE_DIR="$(dirname "$0")"
 
+## DockerHub
+
 # built from ponyc release tag
+NAME="ponylang/shared-docker-ci-x86-64-unknown-linux-builder"
 FROM_TAG=release-alpine
 TAG_AS=release
 docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t ponylang/shared-docker-ci-x86-64-unknown-linux-builder:"${TAG_AS}" \
+  -t "${NAME}:${TAG_AS}" \
   "${DOCKERFILE_DIR}"
-docker push ponylang/shared-docker-ci-x86-64-unknown-linux-builder:"${TAG_AS}"
+docker push "${NAME}:${TAG_AS}"
 
 # built from ponyc latest tag
 FROM_TAG=alpine
 TAG_AS=latest
 docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t ponylang/shared-docker-ci-x86-64-unknown-linux-builder:"${TAG_AS}" \
+  -t "${NAME}:${TAG_AS}" \
   "${DOCKERFILE_DIR}"
-docker push ponylang/shared-docker-ci-x86-64-unknown-linux-builder:"${TAG_AS}"
+docker push "${NAME}:${TAG_AS}"
+
+## GitHub Container Registry
+
+# built from ponyc release tag
+NAME="ghcr.io/ponylang/shared-docker-ci-x86-64-unknown-linux-builder"
+FROM_TAG=release-alpine
+TAG_AS=release
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
+  -t "${NAME}:${TAG_AS}" \
+  "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"
+
+# built from ponyc latest tag
+FROM_TAG=alpine
+TAG_AS=latest
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
+  -t "${NAME}:${TAG_AS}" \
+  "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"


### PR DESCRIPTION
We are going to transition away from DockerHub as the open source plan limits the number of admin users we can have. This means that in addition to having to maintain different access lists (GitHub and DockerHub) for committers, we also have to juggle committer access on DockerHub as we can't ever have more than 3 accounts.

This commit updates all our existing builders to push to both GitHub Container Registry and DockerHub. I did the changes in a way that will make it easy to delete large chunks of the build-and-push scripts once we drop DockerHub.

All action jobs that logged in to DockerHub have a corresponding login to GitHub Container Registry added as well. Once we transition, the DockerHub login steps can be deleted.

This commit also adds steps to delete untagged images for ones that are updated daily with "nightly" or "release" tags. Once we have a new nightly builder of image "X", we don't need to keep the old images around. Keeping them around will really clutter up the UI. Given that an image might be in the process of being pulled elsewhere, we keep around 1 copy of each to avoid "ships passing in the night" errors.

The actionlint image has already been manually generated and is in GitHub Container Registry. All the other images are created on release or for each nightly. Once the first image is added, I will have to manually go into the GitHub UI and set the images as "public" for visibility so that people who aren't part of the ponylang organization can see and use them. This is a one-time step that has to be done when the first instance of an image is pushed.