### PR TITLE
Update to work when base is changing to Alpine 3.18

### DIFF
--- a/x86-64-unknown-linux-builder/Dockerfile
+++ b/x86-64-unknown-linux-builder/Dockerfile
@@ -9,8 +9,6 @@ RUN apk add --update --no-cache \
   bash \
   make \
   build-base \
-  libexecinfo-dev \
-  libexecinfo-static \
   && pip install cloudsmith-cli
 
 RUN git config --global --add safe.directory '*'


### PR DESCRIPTION
The base for our alpine ponyc images is changing from 3.16 to 3.18. To work with that change, we have to drop installing libexec which is no longer available and is now part of musl.