### PR TITLE
Stop pushing new images to DockerHub

### DIFF
--- a/.github/workflows/linux-builder-update.yml
+++ b/.github/workflows/linux-builder-update.yml
@@ -12,11 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Login to DockerHub
-        run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
-        env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
@@ -46,11 +41,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Login to DockerHub
-        run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
-        env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
@@ -80,11 +70,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Login to DockerHub
-        run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
-        env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
@@ -114,11 +99,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Login to DockerHub
-        run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
-        env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
@@ -148,11 +128,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Login to DockerHub
-        run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
-        env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
@@ -182,11 +157,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Login to DockerHub
-        run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
-        env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
@@ -216,11 +186,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Login to DockerHub
-        run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
-        env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
@@ -250,11 +215,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Login to DockerHub
-        run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
-        env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc

--- a/.github/workflows/release-a-library-update.yml
+++ b/.github/workflows/release-a-library-update.yml
@@ -13,11 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Login to DockerHub
-        run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
-        env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc

--- a/actionlint/build-and-push.bash
+++ b/actionlint/build-and-push.bash
@@ -4,17 +4,12 @@ set -o errexit
 set -o nounset
 
 #
-# *** You should already be logged in to DockerHub
-#     and GitHub Container Registry when you run this ***
+# *** You should already be logged in to GitHub Container Registry when you run #     this ***
 #
 
 NAME="ponylang/shared-docker-ci-actionlint"
 TODAY=$(date +%Y%m%d)
 DOCKERFILE_DIR="$(dirname "$0")"
-
-# DockerHub
-docker build --pull -t "${NAME}:${TODAY}" "${DOCKERFILE_DIR}"
-docker push "${NAME}:${TODAY}"
 
 # GitHub Container Registry
 NAME="ghcr.io/${NAME}"

--- a/release-a-library/build-and-push.bash
+++ b/release-a-library/build-and-push.bash
@@ -4,30 +4,11 @@ set -o errexit
 set -o nounset
 
 #
-# *** You should already be logged in to DockerHub
-#     and GitHub Container Registry when you run this ***
+# *** You should already be logged in to GitHub Container Registry when you run
+#     this ***
 #
 
 DOCKERFILE_DIR="$(dirname "$0")"
-
-## DockerHub
-
-# built from ponyc release tag
-NAME="ponylang/shared-docker-ci-release-a-library"
-FROM_TAG=release-alpine
-TAG_AS=release
-docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t "${NAME}:${TAG_AS}" \
-  "${DOCKERFILE_DIR}"
-docker push "${NAME}:${TAG_AS}"
-
-# built from ponyc latest tag
-FROM_TAG=alpine
-TAG_AS=latest
-docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t "${NAME}:${TAG_AS}" \
-  "${DOCKERFILE_DIR}"
-docker push "${NAME}:${TAG_AS}"
 
 ## GitHub Container Registry
 

--- a/x86-64-unknown-linux-builder-with-libressl-3.7.2/build-and-push.bash
+++ b/x86-64-unknown-linux-builder-with-libressl-3.7.2/build-and-push.bash
@@ -4,29 +4,11 @@ set -o errexit
 set -o nounset
 
 #
-# *** You should already be logged in to DockerHub
-#     and GitHub Container Registry when you run this ***
+# *** You should already be logged in to GitHub Container Registry when you run
+#     this ***
 #
 
 DOCKERFILE_DIR="$(dirname "$0")"
-
-## DockerHub
-
-NAME="ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-libressl-3.7.2"
-
-# built from x86-64-unknown-linux-builder release tag
-FROM_TAG=release
-TAG_AS=release
-docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
-docker push "${NAME}:${TAG_AS}"
-
-# built from x86-64-unknown-linux-builder latest tag
-FROM_TAG=latest
-TAG_AS=latest
-docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
-docker push "${NAME}:${TAG_AS}"
 
 ## GitHub Container Registry
 

--- a/x86-64-unknown-linux-builder-with-libressl-3.7.3/build-and-push.bash
+++ b/x86-64-unknown-linux-builder-with-libressl-3.7.3/build-and-push.bash
@@ -4,29 +4,11 @@ set -o errexit
 set -o nounset
 
 #
-# *** You should already be logged in to DockerHub
-#     and GitHub Container Registry when you run this ***
+# *** You should already be logged in to GitHub Container Registry when you run
+#     this ***
 #
 
 DOCKERFILE_DIR="$(dirname "$0")"
-
-## DockerHub
-
-NAME="ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-libressl-3.7.3"
-
-# built from x86-64-unknown-linux-builder release tag
-FROM_TAG=release
-TAG_AS=release
-docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
-docker push "${NAME}:${TAG_AS}"
-
-# built from x86-64-unknown-linux-builder latest tag
-FROM_TAG=latest
-TAG_AS=latest
-docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
-docker push "${NAME}:${TAG_AS}"
 
 ## GitHub Container Registry
 

--- a/x86-64-unknown-linux-builder-with-openssl_1.1.1t/build-and-push.bash
+++ b/x86-64-unknown-linux-builder-with-openssl_1.1.1t/build-and-push.bash
@@ -4,29 +4,11 @@ set -o errexit
 set -o nounset
 
 #
-# *** You should already be logged in to DockerHub
-#     and GitHub Container Registry when you run this ***
+# *** You should already be logged in to GitHub Container Registry when you run
+#     this ***
 #
 
 DOCKERFILE_DIR="$(dirname "$0")"
-
-## DockerHub
-
-NAME="ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_1.1.1t"
-
-# built from x86-64-unknown-linux-builder release tag
-FROM_TAG=release
-TAG_AS=release
-docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
-docker push "${NAME}:${TAG_AS}"
-
-# built from x86-64-unknown-linux-builder latest tag
-FROM_TAG=latest
-TAG_AS=latest
-docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
-docker push "${NAME}:${TAG_AS}"
 
 ## GitHub Container Registry
 

--- a/x86-64-unknown-linux-builder-with-openssl_1.1.1w/build-and-push.bash
+++ b/x86-64-unknown-linux-builder-with-openssl_1.1.1w/build-and-push.bash
@@ -4,29 +4,11 @@ set -o errexit
 set -o nounset
 
 #
-# *** You should already be logged in to DockerHub
-#     and GitHub Container Registry when you run this ***
+# *** You should already be logged in to GitHub Container Registry when you run
+#     this ***
 #
 
 DOCKERFILE_DIR="$(dirname "$0")"
-
-## DockerHub
-
-NAME="ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_1.1.1w"
-
-# built from x86-64-unknown-linux-builder release tag
-FROM_TAG=release
-TAG_AS=release
-docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
-docker push "${NAME}:${TAG_AS}"
-
-# built from x86-64-unknown-linux-builder latest tag
-FROM_TAG=latest
-TAG_AS=latest
-docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
-docker push "${NAME}:${TAG_AS}"
 
 ## GitHub Container Registry
 

--- a/x86-64-unknown-linux-builder-with-openssl_3.1.0/build-and-push.bash
+++ b/x86-64-unknown-linux-builder-with-openssl_3.1.0/build-and-push.bash
@@ -4,29 +4,11 @@ set -o errexit
 set -o nounset
 
 #
-# *** You should already be logged in to DockerHub
-#     and GitHub Container Registry when you run this ***
+# *** You should already be logged in to GitHub Container Registry when you run
+#     this ***
 #
 
 DOCKERFILE_DIR="$(dirname "$0")"
-
-## DockerHub
-
-NAME="ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_3.1.0"
-
-# built from x86-64-unknown-linux-builder release tag
-FROM_TAG=release
-TAG_AS=release
-docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
-docker push "${NAME}:${TAG_AS}"
-
-# built from x86-64-unknown-linux-builder latest tag
-FROM_TAG=latest
-TAG_AS=latest
-docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
-docker push "${NAME}:${TAG_AS}"
 
 ## GitHub Container Registry
 

--- a/x86-64-unknown-linux-builder-with-openssl_3.1.3/build-and-push.bash
+++ b/x86-64-unknown-linux-builder-with-openssl_3.1.3/build-and-push.bash
@@ -4,29 +4,10 @@ set -o errexit
 set -o nounset
 
 #
-# *** You should already be logged in to DockerHub
-#     and GitHub Container Registry when you run this ***
+# *** You should already be logged in to GitHub Container Registry when you run
+#     this ***
 #
-
 DOCKERFILE_DIR="$(dirname "$0")"
-
-## DockerHub
-
-NAME="ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_3.1.3"
-
-# built from x86-64-unknown-linux-builder release tag
-FROM_TAG=release
-TAG_AS=release
-docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
-docker push "${NAME}:${TAG_AS}"
-
-# built from x86-64-unknown-linux-builder latest tag
-FROM_TAG=latest
-TAG_AS=latest
-docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
-docker push "${NAME}:${TAG_AS}"
 
 ## GitHub Container Registry
 

--- a/x86-64-unknown-linux-builder-with-pcre/build-and-push.bash
+++ b/x86-64-unknown-linux-builder-with-pcre/build-and-push.bash
@@ -4,31 +4,11 @@ set -o errexit
 set -o nounset
 
 #
-# *** You should already be logged in to DockerHub
-#     and GitHub Container Registry when you run this ***
+# *** You should already be logged in to GitHub Container Registry when you run
+#     this ***
 #
 
 DOCKERFILE_DIR="$(dirname "$0")"
-
-## DockerHub
-
-NAME="ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-pcre"
-
-# built from x86-64-unknown-linux-builder release tag
-FROM_TAG=release
-TAG_AS=release
-docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t "${NAME}:${TAG_AS}" \
-  "${DOCKERFILE_DIR}"
-docker push "${NAME}:${TAG_AS}"
-
-# built from x86-64-unknown-linux-builder latest tag
-FROM_TAG=latest
-TAG_AS=latest
-docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t "${NAME}:${TAG_AS}" \
-  "${DOCKERFILE_DIR}"
-docker push "${NAME}:${TAG_AS}"
 
 ## GitHub Container Registry
 

--- a/x86-64-unknown-linux-builder/build-and-push.bash
+++ b/x86-64-unknown-linux-builder/build-and-push.bash
@@ -4,30 +4,11 @@ set -o errexit
 set -o nounset
 
 #
-# *** You should already be logged in to DockerHub
-#     and GitHub Container Registry when you run this ***
+# *** You should already be logged in to GitHub Container Registry when you run
+#     this ***
 #
 
 DOCKERFILE_DIR="$(dirname "$0")"
-
-## DockerHub
-
-# built from ponyc release tag
-NAME="ponylang/shared-docker-ci-x86-64-unknown-linux-builder"
-FROM_TAG=release-alpine
-TAG_AS=release
-docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t "${NAME}:${TAG_AS}" \
-  "${DOCKERFILE_DIR}"
-docker push "${NAME}:${TAG_AS}"
-
-# built from ponyc latest tag
-FROM_TAG=alpine
-TAG_AS=latest
-docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t "${NAME}:${TAG_AS}" \
-  "${DOCKERFILE_DIR}"
-docker push "${NAME}:${TAG_AS}"
 
 ## GitHub Container Registry
 


### PR DESCRIPTION
We've transitioned off of DockerHub and only use GitHub Container Registry.