### PR TITLE
Add OpenSSL 3.2.0 builder

### DIFF
--- a/.github/workflows/linux-builder-update.yml
+++ b/.github/workflows/linux-builder-update.yml
@@ -207,6 +207,35 @@ jobs:
           topic: ${{ github.repository }} scheduled job failure
           content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
 
+  x86-64-unknown-linux-builder-with-openssl_3_2_0:
+    needs:
+      - x86-64-unknown-linux-builder
+
+    name: Update x86-64-unknown-linux-builder-with-openssl_3.2.0
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        run: bash x86-64-unknown-linux-builder-with-openssl_3.2.0/build-and-push.bash
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@b62d5a0e48a4d984ea4fce5dd65ba691963d4db4
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
   x86-64-unknown-linux-builder-with-pcre:
     needs:
       - x86-64-unknown-linux-builder
@@ -245,6 +274,7 @@ jobs:
       - x86-64-unknown-linux-builder-with-openssl_1_1_1w
       - x86-64-unknown-linux-builder-with-openssl_3_1_0
       - x86-64-unknown-linux-builder-with-openssl_3_1_3
+      - x86-64-unknown-linux-builder-with-openssl_3_2_0
       - x86-64-unknown-linux-builder-with-pcre
 
     name: Send 'shared-docker-linux-builders-updated' event
@@ -318,6 +348,7 @@ jobs:
           - shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_1.1.1w
           - shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_3.1.0
           - shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_3.1.3
+          - shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_3.2.0
           - shared-docker-ci-x86-64-unknown-linux-builder-with-pcre
 
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -102,6 +102,14 @@ jobs:
       - name: Docker build
         run: "docker build --pull --file=x86-64-unknown-linux-builder-with-openssl_3.1.3/Dockerfile ."
 
+  validate-x86-64-unknown-linux-builder-with-openssl_3_2_0-image-builds:
+    name: Validate x86-64-unknown-linux-builder-with-openssl_3.2.0 Docker image builds
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Docker build
+        run: "docker build --pull --file=x86-64-unknown-linux-builder-with-openssl_3.2.0/Dockerfile ."
+
   validate-x86-64-unknown-linux-builder-with-pcre-image-builds:
     name: Validate x86-64-unknown-linux-builder-with-pcre Docker image builds
     runs-on: ubuntu-latest

--- a/x86-64-unknown-linux-builder-with-openssl_3.2.0/Dockerfile
+++ b/x86-64-unknown-linux-builder-with-openssl_3.2.0/Dockerfile
@@ -1,0 +1,22 @@
+ARG FROM_TAG=release
+FROM ghcr.io/ponylang/shared-docker-ci-x86-64-unknown-linux-builder:${FROM_TAG}
+
+RUN apk add --update --no-cache \
+  clang-dev \
+  linux-headers \
+  perl
+
+RUN cd /tmp && \
+  wget https://www.openssl.org/source/openssl-3.2.0.tar.gz && \
+  tar xf openssl-3.2.0.tar.gz && \
+  cd openssl-3.2.0 && \
+  ./Configure --api=3.0.0 no-shared linux-x86_64 enable-rc5 enable-md2 && \
+  make && \
+  make install && \
+  cd /tmp && \
+  rm -rf openssl-3.2.0
+
+# For some reason, even though lib64 is in the linker search path, the
+# libraries when installed there can't be found
+RUN cp /usr/local/lib64/libssl.a /usr/local/lib/ && \
+  cp /usr/local/lib64/libcrypto.a /usr/local/lib

--- a/x86-64-unknown-linux-builder-with-openssl_3.2.0/README.md
+++ b/x86-64-unknown-linux-builder-with-openssl_3.2.0/README.md
@@ -1,0 +1,3 @@
+# x86-64-unknown-linux-builder-with-openssl_3.2.0
+
+The x86-64-unknown-linux-builder with OpenSSL 3.2.0 implementation installed as well. Rebuilt daily.

--- a/x86-64-unknown-linux-builder-with-openssl_3.2.0/build-and-push.bash
+++ b/x86-64-unknown-linux-builder-with-openssl_3.2.0/build-and-push.bash
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+#
+# *** You should already be logged in to GitHub Container Registry when you run
+#     this ***
+#
+DOCKERFILE_DIR="$(dirname "$0")"
+
+## GitHub Container Registry
+
+NAME="ghcr.io/ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_3.2.0"
+
+# built from x86-64-unknown-linux-builder release tag
+FROM_TAG=release
+TAG_AS=release
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
+  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"
+
+# built from x86-64-unknown-linux-builder latest tag
+FROM_TAG=latest
+TAG_AS=latest
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
+  -t "${NAME}:${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TAG_AS}"


### PR DESCRIPTION
A bug with 3.2.0 has been reported, so we are creating a builder now even though we aren't at our usual "update SSL builders every 6 months" date.