### PR TITLE
Update some OpenSSL download locations

### DIFF
--- a/x86-64-unknown-linux-builder-with-openssl_3.1.0/Dockerfile
+++ b/x86-64-unknown-linux-builder-with-openssl_3.1.0/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --update --no-cache \
   perl
 
 RUN cd /tmp && \
-  wget https://www.openssl.org/source/openssl-3.1.0.tar.gz && \
+  wget https://www.openssl.org/source/old/3.1/openssl-3.1.0.tar.gz && \
   tar xf openssl-3.1.0.tar.gz && \
   cd openssl-3.1.0 && \
   ./Configure --api=3.0.0 no-shared linux-x86_64 enable-rc5 enable-md2 && \

--- a/x86-64-unknown-linux-builder-with-openssl_3.1.3/Dockerfile
+++ b/x86-64-unknown-linux-builder-with-openssl_3.1.3/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --update --no-cache \
   perl
 
 RUN cd /tmp && \
-  wget https://www.openssl.org/source/openssl-3.1.3.tar.gz && \
+  wget https://www.openssl.org/source/old/3.1/openssl-3.1.3.tar.gz && \
   tar xf openssl-3.1.3.tar.gz && \
   cd openssl-3.1.3 && \
   ./Configure --api=3.0.0 no-shared linux-x86_64 enable-rc5 enable-md2 && \


### PR DESCRIPTION
They appear to now move "old" releases to new directories so that once something becomes "old", we will have to redo the location.

This broke on us today for these two 3.1.x versions.