### PR TITLE
Update builder images from Alpine 3.18 to 3.20

### DIFF
--- a/actionlint/Dockerfile
+++ b/actionlint/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18 AS builder
+FROM alpine:3.20 AS builder
 
 RUN apk add --update --no-cache \
   bash \

--- a/emacs-mode-release/Dockerfile
+++ b/emacs-mode-release/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18
+FROM alpine:3.20
 
 RUN apk add --update --no-cache \
   bash \


### PR DESCRIPTION
3.18 is now EOL.