### PR TITLE
Add livery to builders-updated notifications

### DIFF
--- a/.github/workflows/rebuild-ponyc-based-images.yml
+++ b/.github/workflows/rebuild-ponyc-based-images.yml
@@ -419,6 +419,7 @@ jobs:
           - ponylang/hobby
           - ponylang/http
           - ponylang/http_server
+          - ponylang/livery
           - ponylang/logger
           - ponylang/lori
           - ponylang/mare


### PR DESCRIPTION
Add livery to the list of repositories that receive the shared-docker-builders-updated event when Linux builder images are rebuilt.