### PR TITLE
Add standard-builder-with-openssl-3.6.2

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -121,6 +121,18 @@ jobs:
       - name: Test build
         run: "docker buildx build --pull --file=standard-builder-with-openssl-3.6.0/Dockerfile ."
 
+  validate-standard-builder-with-openssl-3_6_2-builds:
+    name: Validate standard builder with openssl 3.6.2 image builds
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+      - name: Set up buildx
+        # v3.10.0
+        uses: docker/setup-buildx-action@v4
+      - name: Test build
+        run: "docker buildx build --pull --file=standard-builder-with-openssl-3.6.2/Dockerfile ."
+
   validate-standard-builder-with-pcre-builds:
     name: Validate standard builder with pcre image builds
     runs-on: ubuntu-latest

--- a/.github/workflows/rebuild-ponyc-based-images.yml
+++ b/.github/workflows/rebuild-ponyc-based-images.yml
@@ -391,6 +391,109 @@ jobs:
           topic: ${{ github.repository }} scheduled job failure
           content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
 
+  standard-builder-with-openssl_3_6_2-amd64:
+    needs:
+      - standard-builder
+
+    name: Update standard-builder-with-openssl-3.6.2 on amd64
+    runs-on: ubuntu-latest
+
+    concurrency:
+      group: standard-builder-with-openssl_3_6_2-amd64
+      cancel-in-progress: true
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        run: bash standard-builder-with-openssl-3.6.2/build-and-push.bash
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
+  standard-builder-with-openssl_3_6_2-arm64:
+    needs:
+      - standard-builder
+
+    name: Update standard-builder-with-openssl-3.6.2 on arm64
+    runs-on: ubuntu-24.04-arm
+
+    concurrency:
+      group: standard-builder-with-openssl_3_6_2-arm64
+      cancel-in-progress: true
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        run: bash standard-builder-with-openssl-3.6.2/build-and-push.bash
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
+  merge-standard-builder-with-openssl_3_6_2:
+    needs:
+      - standard-builder-with-openssl_3_6_2-amd64
+      - standard-builder-with-openssl_3_6_2-arm64
+
+    name: Create merged standard-builder-with-openssl-3.6.2
+    runs-on: ubuntu-latest
+
+    concurrency:
+      group: merge-standard-builder-with-openssl_3_6_2
+      cancel-in-progress: true
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Merge
+        run: bash standard-builder-with-openssl-3.6.2/combine-images.bash
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
   x86-64-unknown-linux-builder-with-libressl_3_9_2:
     needs:
       - standard-builder
@@ -501,6 +604,7 @@ jobs:
       - merge-standard-builder-with-libressl_4_2_0
       - merge-standard-builder-with-libressl_4_2_1
       - merge-standard-builder-with-openssl_3_6_0
+      - merge-standard-builder-with-openssl_3_6_2
       - x86-64-unknown-linux-builder-with-libressl_3_9_2
       - x86-64-unknown-linux-builder-with-openssl_1_1_1w
       - x86-64-unknown-linux-builder-with-openssl_3_4_1
@@ -582,6 +686,7 @@ jobs:
           - shared-docker-ci-standard-builder-with-libressl-4.2.0
           - shared-docker-ci-standard-builder-with-libressl-4.2.1
           - shared-docker-ci-standard-builder-with-openssl-3.6.0
+          - shared-docker-ci-standard-builder-with-openssl-3.6.2
 
     steps:
       - name: Login to GitHub Container Registry

--- a/standard-builder-with-openssl-3.6.2/Dockerfile
+++ b/standard-builder-with-openssl-3.6.2/Dockerfile
@@ -1,0 +1,18 @@
+ARG FROM_TAG=release
+FROM ghcr.io/ponylang/shared-docker-ci-standard-builder:${FROM_TAG}
+
+LABEL org.opencontainers.image.source="https://github.com/ponylang/shared-docker"
+
+RUN apk add --update --no-cache \
+  clang-dev \
+  linux-headers \
+  perl
+
+RUN cd /tmp && \
+  wget https://github.com/openssl/openssl/releases/download/openssl-3.6.2/openssl-3.6.2.tar.gz && \
+  tar xf openssl-3.6.2.tar.gz && \
+  cd openssl-3.6.2 && \
+  ./Configure --api=3.0.0 no-shared enable-rc5 enable-md2 && \
+  make install_sw && \
+  cd /tmp && \
+  rm -rf openssl-3.6.2

--- a/standard-builder-with-openssl-3.6.2/README.md
+++ b/standard-builder-with-openssl-3.6.2/README.md
@@ -1,0 +1,3 @@
+# standard-builder-with-openssl-3.6.2
+
+The standard-builder with OpenSSL 3.6.2 installed as well. Rebuilt daily.

--- a/standard-builder-with-openssl-3.6.2/build-and-push.bash
+++ b/standard-builder-with-openssl-3.6.2/build-and-push.bash
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+#
+# *** You should already be logged in to GitHub Container Registry when you run
+#     this ***
+#
+
+ARCH=$(uname -m)
+case "${ARCH}" in
+  x86_64)
+    ARCH_TAG="amd64"
+    ;;
+  aarch64|arm64)
+    ARCH_TAG="arm64"
+    ;;
+  *)
+    echo "Error: Unsupported architecture '${ARCH}'" >&2
+    exit 1
+    ;;
+esac
+
+DOCKERFILE_DIR="$(dirname "$0")"
+BUILDER="standard-builder-with-openssl-3.6.2-$(date +%s)"
+NAME="ghcr.io/ponylang/shared-docker-ci-standard-builder-with-openssl-3.6.2"
+
+echo "Building nightly image from standard-builder nightly tag"
+docker buildx create --use --name "${BUILDER}"
+docker buildx build --provenance false --sbom false \
+  --pull --push --build-arg \
+  FROM_TAG="nightly" -t "${NAME}:nightly-${ARCH_TAG}" "${DOCKERFILE_DIR}"
+docker buildx rm "${BUILDER}"
+
+echo "Building release image from standard-builder release tag"
+docker buildx create --use --name "${BUILDER}"
+docker buildx build --provenance false --sbom false \
+  --pull --push --build-arg \
+  FROM_TAG="release" -t "${NAME}:release-${ARCH_TAG}" "${DOCKERFILE_DIR}"
+docker buildx rm "${BUILDER}"

--- a/standard-builder-with-openssl-3.6.2/combine-images.bash
+++ b/standard-builder-with-openssl-3.6.2/combine-images.bash
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+# The tag names used here (nightly, release) must stay in sync with the
+# prune-untagged-multiplatform-images job in rebuild-ponyc-based-images.yml,
+# which inspects these tags to collect child SHAs for skip-shas protection.
+NAME="ghcr.io/ponylang/shared-docker-ci-standard-builder-with-openssl-3.6.2"
+
+sources=()
+
+# function to check if an image exists
+check_image() {
+  local image="$1"
+  if docker manifest inspect "$image" > /dev/null 2>&1; then
+    echo "Image exists: $image"
+    sources+=("$image")
+  else
+    echo "Image not found: $image"
+  fi
+}
+
+merge_images() {
+  local TAG="$1"
+  echo "Checking available architecture images for ${NAME}:$TAG"
+
+  check_image "${NAME}:${TAG}-amd64"
+  check_image "${NAME}:${TAG}-arm64"
+
+  if [ ${#sources[@]} -eq 0 ]; then
+    echo "No images found for merging, skipping."
+    return
+  fi
+
+  echo "Creating or updating manifest tag: ${NAME}:${TAG}"
+
+  # Attempt to inspect existing manifest
+  if docker manifest inspect "${NAME}:${TAG}" >/dev/null 2>&1; then
+    echo "Existing manifest found, updating it."
+    docker manifest create --amend "${NAME}:${TAG}" "${sources[@]}"
+  else
+    echo "No existing manifest found, creating new one."
+    docker manifest create "${NAME}:${TAG}" "${sources[@]}"
+  fi
+  docker manifest push "${NAME}:${TAG}"
+
+  echo "Manifest created or updated successfully."
+}
+
+merge_images "nightly"
+merge_images "release"


### PR DESCRIPTION
OpenSSL 3.6.2 is the latest release across the active 3.x branches (released 2026-04-07). Adds a new multiplatform builder image.

The 3.6.0 image is kept available for one cycle to give users time to migrate; it will be removed in the next SSL builder update cycle.