### PR TITLE
Fix /update-ssl-builders LWIP timing

### DIFF
--- a/.claude/skills/update-ssl-builders/SKILL.md
+++ b/.claude/skills/update-ssl-builders/SKILL.md
@@ -69,6 +69,10 @@ Each add gets its own PR.
 7. Edit `.github/workflows/pr.yml` — add a `validate-standard-builder-with-<library>-<version>-builds` job following the existing `validate-standard-builder-with-libressl-4_2_0-builds` pattern. This is what proves "it builds" at PR time; `rebuild-ponyc-based-images.yml` won't fire until the next ponyc nightly/release event. Use underscores for version separators in the job key; the name and file path use dots.
 8. Commit, push, open PR. Commit message explains which builder is being added and why (new upstream release).
 9. Wait for CI to pass — especially the new `validate-...-builds` job, which is the actual build verification. Squash-merge. The builder's first real tagged image on ghcr.io is published when the next ponyc nightly or release triggers `rebuild-ponyc-based-images.yml`.
+10. Post the "Last Week in Pony" note to the current week's LWIP issue as soon as this PR merges — don't batch notes until the whole cycle is done. Announce the new builder, note which prior-version builder will be removed next cycle, and tell users they should migrate before that happens. If unsure where the current LWIP issue lives, ask the user.
+
+Example phrasing:
+> A new OpenSSL 3.6.2 builder image is now available. The prior OpenSSL 3.6.0 image will be removed during the next SSL builder update, so any project still using 3.6.0 should plan to migrate.
 
 ## Phase 5: Per-drop workflow (one PR per drop)
 
@@ -83,24 +87,9 @@ Each drop gets its own PR.
 4. Edit `.github/workflows/pr.yml` — remove the corresponding `validate-<builder>-builds` job.
 5. Commit, push, open PR.
 6. Wait for CI to pass. Squash-merge.
-
-Dropping is code-only. Existing tagged images on ghcr.io are left intact. They simply stop receiving updates — rebuilds only happen when a new ponyc nightly or release image triggers the workflow, and a dropped builder is no longer part of that flow.
-
-## Phase 6: "Last Week in Pony" notes
-
-After all PRs are merged, post notes to the current week's "Last Week in Pony" issue. If unsure where that issue lives, ask the user.
-
-**Per added builder**:
-- Announce the new builder is available.
-- Note which prior-version builder will be removed next cycle.
-- Tell users they should migrate before that happens.
-
-Example phrasing:
-> A new OpenSSL 3.6.2 builder image is now available. The prior OpenSSL 3.6.0 image will be removed during the next SSL builder update, so any project still using 3.6.0 should plan to migrate.
-
-**Per dropped builder**:
-- Note the builder is gone.
-- Note it will receive no further updates. Builders only get rebuilt when a new ponyc nightly or release image is produced; a dropped builder is no longer part of that flow.
+7. Post the "Last Week in Pony" note to the current week's LWIP issue as soon as this PR merges — don't batch notes until the whole cycle is done. Note the builder is gone and will receive no further updates (builders only get rebuilt when a new ponyc nightly or release image triggers `rebuild-ponyc-based-images.yml`). If unsure where the current LWIP issue lives, ask the user.
 
 Example phrasing:
 > The OpenSSL 3.4.1 builder image has been removed and will receive no further updates. Any projects still using it should switch to a current builder.
+
+Dropping is code-only. Existing tagged images on ghcr.io are left intact. They simply stop receiving updates — rebuilds only happen when a new ponyc nightly or release image triggers the workflow, and a dropped builder is no longer part of that flow.


### PR DESCRIPTION
Notes should go up as each PR merges, not batched at the end of the cycle. Folds the LWIP step into Phases 4 and 5 and removes Phase 6.