### PR TITLE
Remove stale libressl-4.0.0 entry from prune matrix

### DIFF
--- a/.github/workflows/rebuild-ponyc-based-images.yml
+++ b/.github/workflows/rebuild-ponyc-based-images.yml
@@ -813,7 +813,6 @@ jobs:
       matrix:
         image:
           - shared-docker-ci-x86-64-unknown-linux-builder-with-libressl-3.9.2
-          - shared-docker-ci-x86-64-unknown-linux-builder-with-libressl-4.0.0
           - shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_1.1.1w
 
     steps:


### PR DESCRIPTION
The builder was dropped in a prior cycle but its image name was left behind in the `prune-untagged-builder-images` matrix. No builder folder or CI job references it.

Closes #121