### PR TITLE
Stop sending builders-updated event to http and http_server

### DIFF
--- a/.github/workflows/rebuild-ponyc-based-images.yml
+++ b/.github/workflows/rebuild-ponyc-based-images.yml
@@ -695,8 +695,6 @@ jobs:
           - ponylang/github_rest_api
           - ponylang/glob
           - ponylang/hobby
-          - ponylang/http
-          - ponylang/http_server
           - ponylang/livery
           - ponylang/logger
           - ponylang/lori


### PR DESCRIPTION
Removes `ponylang/http` and `ponylang/http_server` from the matrix in the `send-builders-updated-event` job of `rebuild-ponyc-based-images.yml`. Those two repositories will no longer receive the `shared-docker-builders-updated` repository dispatch event when the builder images are rebuilt.