### PR TITLE
Update actions/delete-package-versions to v5.0.0

### DIFF
--- a/.github/workflows/release-a-library-update.yml
+++ b/.github/workflows/release-a-library-update.yml
@@ -47,8 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Prune
-        # v4.1.1
-        uses: actions/delete-package-versions@0d39a63126868f5eefaa47169615edd3c0f61e20
+        # v5.0.0
+        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55
         with:
           package-name: 'shared-docker-ci-release-a-library'
           package-type: 'container'


### PR DESCRIPTION
Bumps the pinned `actions/delete-package-versions` from v4.1.1 to v5.0.0 in the "Prune untagged images" step of `release-a-library-update.yml`.

v4.1.1 runs on the deprecated node16 Actions runtime; v5.0.0 moves to node20. The action's inputs are identical between the two versions, so this is a drop-in bump with no configuration changes.